### PR TITLE
fix: disable pointer-events on the batman meme

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -67,6 +67,7 @@ const { title } = Astro.props;
     backdrop-filter: blur(10px);
     inset: 0;
     transition: opacity 100ms;
+    pointer-events: none;
 
     & > img {
       position: fixed;


### PR DESCRIPTION
Le meme opaque attrape le clic sur la majorité de la slide depuis que j'ai changé le `display: none` en `opacity: 0` ! 🙈 