### PR TITLE
fix: break-word in paragraph

### DIFF
--- a/src/slides/1-demos/text-card/demo/styles.css
+++ b/src/slides/1-demos/text-card/demo/styles.css
@@ -20,4 +20,5 @@ body {
 	border-radius: 0.5em;
 	box-shadow: 0 4px 4px -4px hsl(240 4% 5% / 0.05),
 		0 16px 32px -4px hsl(240 4% 5% / 0.1);
+  word-break: break-word;
 }


### PR DESCRIPTION
J'ai remarqué que si je mets la font-size à 200% sur le paragraph, la largeur limitée est pas respectée parce que les mots les plus longs (non-coupés) sont plus longs que la largeur:
<img width="1271" alt="image" src="https://github.com/user-attachments/assets/912af6a5-aca4-42fa-b0af-0ed788c80e9c">

Du coup j'ai mis un break-word, ça coupe les mots n'importe comment mais si on scrolle pas ça se voit pas et ça fixe le problème de largeur. Perso ce compromis me va mais je suis curieux d'avoir ton avis, ou s'il y a une autre solution.